### PR TITLE
Added autodetect of configuration

### DIFF
--- a/src/core/Querator.js
+++ b/src/core/Querator.js
@@ -66,14 +66,12 @@ export class Querator {
   /**
    * @param {object} options
    * @param {'redis' | 'rabbitmq' | 'mqtt'} options.engine
-   * @param {'manual' | 'json' | 'yaml' | 'toml'} options.configuration
-   * @param {string} options.file
-   * @param {object} options.settings
+   * @param {string} [options.file]
+   * @param {object} [options.settings]
    */
   constructor (options) {
     try {
       if (!options) throw new Error('Querator config must be provided')
-      if (!options.configuration) throw new Error('Querator configuration type must be provided')
 
       const validateOptions = Validator.check(queratorConstructorSchema, options)
 
@@ -83,13 +81,12 @@ export class Querator {
 
       this.#BROKER_TYPE = options.engine
 
-      if (options.configuration === 'manual') {
-        this.#BROKER_SETTINGS = options.settings ? options.settings : null
+      if (options.file) {
+        this.#BROKER_SETTINGS = parseSettings(options.file)
       } else {
-        this.#BROKER_SETTINGS = parseSettings(options.configuration, options.file)
-
-        if (this.#BROKER_SETTINGS === null) throw new Error('Failed to read config file')
+        this.#BROKER_SETTINGS = options.settings || {}
       }
+
       console.log(this.#BROKER_SETTINGS)
     } catch (error) {
       Logger.error('Querator constructor error', { error })

--- a/src/schemas/queratorConstructorSchema.js
+++ b/src/schemas/queratorConstructorSchema.js
@@ -6,11 +6,6 @@ export const queratorConstructorSchema = {
       enum: ['redis', 'rabbitmq', 'mqtt', 'kafka'],
       nullable: false
     },
-    configuration: {
-      type: 'string',
-      enum: ['manual', 'json', 'yaml', 'toml'],
-      nullable: false
-    },
     file: {
       type: 'string',
       nullable: false
@@ -20,6 +15,6 @@ export const queratorConstructorSchema = {
       nullable: true
     }
   },
-  required: ['engine', 'configuration'],
+  required: ['engine'],
   additionalProperties: false
 }

--- a/src/utils/parseSettings.js
+++ b/src/utils/parseSettings.js
@@ -2,37 +2,38 @@ import { Logger } from './Logger.js'
 import fs from 'fs'
 import YAML from 'yaml'
 import toml from 'toml'
+import path from 'path'
 
-export const parseSettings = (type, filename) => {
+export const parseSettings = (filename) => {
   try {
-    if (!type) throw new Error('Settings type must be provided')
     if (!filename) throw new Error('Filename must be provided')
 
-    const path = new URL(`${process.cwd()}/${filename}`, import.meta.url)
-    const data = fs.readFileSync(path)
+    const file = new URL(`${process.cwd()}/${filename}`, import.meta.url)
+    const data = fs.readFileSync(file)
 
     if (!data) throw new Error('Failed to read broker settings file')
 
     let result
 
-    switch (type) {
-      case 'json': {
+    switch (path.extname(filename)) {
+      case '.json': {
         result = JSON.parse(data)
         break
       }
 
-      case 'yaml': {
+      case '.yaml': {
         result = YAML.parse(data.toString())
         break
       }
 
-      case 'toml': {
+      case '.toml': {
         result = toml.parse(data)
         break
       }
 
-      default:
-        break
+      default: {
+        throw new Error('Unknown format of settings file')
+      }
     }
 
     return result

--- a/src/utils/parseSettings.js
+++ b/src/utils/parseSettings.js
@@ -21,7 +21,8 @@ export const parseSettings = (filename) => {
         break
       }
 
-      case '.yaml': {
+      case '.yaml':
+      case '.yml': {
         result = YAML.parse(data.toString())
         break
       }


### PR DESCRIPTION
I removed the `configuration` option.
- If `file` option is present, then configuration type will be obtained from the file extension.
- Else if `settings` option is present, then configuration will be taken from there.
- Else by default configuration will be empty object.